### PR TITLE
docs: fix api documents links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ await client.testWebhookEndpoint();
 
 The whole project has been rewritten with TypeScript and all APIs now accept camelcase keys instead of snakecase keys.
 
-Please checkout [the new API document](https://yoctol.github.io/messaging-apis/latest/globals.html).
+Please checkout [the new API document](https://bottenderjs.github.io/messaging-apis/latest/index.html).
 
 # 0.8.4 / 2019-09-29
 

--- a/packages/messaging-api-messenger/README.md
+++ b/packages/messaging-api-messenger/README.md
@@ -111,27 +111,27 @@ All methods return a Promise.
 
 ### Content Types - [Content types](https://developers.facebook.com/docs/messenger-platform/send-api-reference/contenttypes)
 
-- [sendText](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendtext)
-- [sendAttachment](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendattachment)
-- [sendAudio](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendaudio)
-- [sendImage](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendimage)
-- [sendVideo](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendvideo)
-- [sendFile](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendfile)
+- [sendText](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendtext)
+- [sendAttachment](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendattachment)
+- [sendAudio](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendaudio)
+- [sendImage](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendimage)
+- [sendVideo](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendvideo)
+- [sendFile](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendfile)
 
 <a id="templates" />
 
 ### Templates - [Official Docs](https://developers.facebook.com/docs/messenger-platform/send-api-reference/templates)
 
-- [sendTemplate](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendtemplate)
-- [sendButtonTemplate](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendbuttontemplate)
-- [sendGenericTemplate](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendgenerictemplate)
-- [sendMediaTemplate](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendmediatemplate)
-- [sendReceiptTemplate](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendreceipttemplate)
-- [sendAirlineBoardingPassTemplate](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendairlineboardingpasstemplate)
-- [sendAirlineCheckinTemplate](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendairlinecheckintemplate)
-- [sendAirlineItineraryTemplate](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendairlineitinerarytemplate)
-- [sendAirlineUpdateTemplate](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendairlineupdatetemplate)
-- [sendOneTimeNotifReqTemplate](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendonetimenotifreqtemplate)
+- [sendTemplate](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendtemplate)
+- [sendButtonTemplate](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendbuttontemplate)
+- [sendGenericTemplate](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendgenerictemplate)
+- [sendMediaTemplate](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendmediatemplate)
+- [sendReceiptTemplate](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendreceipttemplate)
+- [sendAirlineBoardingPassTemplate](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendairlineboardingpasstemplate)
+- [sendAirlineCheckinTemplate](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendairlinecheckintemplate)
+- [sendAirlineItineraryTemplate](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendairlineitinerarytemplate)
+- [sendAirlineUpdateTemplate](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendairlineupdatetemplate)
+- [sendOneTimeNotifReqTemplate](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendonetimenotifreqtemplate)
 
 <br />
 
@@ -179,10 +179,10 @@ It works with all of message sending methods.
 
 <img src="https://user-images.githubusercontent.com/3382565/37411363-9b65ecaa-27dd-11e8-8f51-7aac7fd0bd2f.png" alt="Sender Actions" width="250" />
 
-- [sendSenderAction](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendsenderaction)
-- [markSeen](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#markseen)
-- [typingOn](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#typingon)
-- [typingOff](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#typingoff)
+- [sendSenderAction](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendsenderaction)
+- [markSeen](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#markseen)
+- [typingOn](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#typingon)
+- [typingOff](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#typingoff)
 
 <a id="attachment-upload-api" />
 
@@ -190,11 +190,11 @@ It works with all of message sending methods.
 
 > Note: Only attachments that were uploaded with the `isReusable` property set to `true` can be sent to other message recipients.
 
-- [uploadAttachment](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#uploadattachment)
-- [uploadAudio](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#uploadaudio)
-- [uploadImage](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#uploadimage)
-- [uploadVideo](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#uploadvideo)
-- [uploadFile](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#uploadfile)
+- [uploadAttachment](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#uploadattachment)
+- [uploadAudio](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#uploadaudio)
+- [uploadImage](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#uploadimage)
+- [uploadVideo](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#uploadvideo)
+- [uploadFile](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#uploadfile)
 
 <br />
 
@@ -202,7 +202,7 @@ It works with all of message sending methods.
 
 ### Message Batching - [Official Docs](https://developers.facebook.com/docs/graph-api/making-multiple-requests)
 
-- [sendBatch](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendbatch)
+- [sendBatch](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#sendbatch)
 
 There are a bunch of factory methods can be used to create batch requests:
 
@@ -244,13 +244,13 @@ Those methods have exactly same argument signature with the methods on client.
 
 ### Custom Labels - [Official Docs](https://developers.facebook.com/docs/messenger-platform/identity/custom-labels)
 
-- [createLabel](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#createlabel)
-- [associateLabel](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#associatelabel)
-- [dissociateLabel](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#dissociatelabel)
-- [getAssociatedLabels](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getassociatedlabels)
-- [getLabelDetails](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getlabeldetails)
-- [getLabelList](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getlabellist)
-- [deleteLabel](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#deletelabel)
+- [createLabel](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#createlabel)
+- [associateLabel](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#associatelabel)
+- [dissociateLabel](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#dissociatelabel)
+- [getAssociatedLabels](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getassociatedlabels)
+- [getLabelDetails](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getlabeldetails)
+- [getLabelList](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getlabellist)
+- [deleteLabel](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#deletelabel)
 
 <br />
 
@@ -258,7 +258,7 @@ Those methods have exactly same argument signature with the methods on client.
 
 ### User Profile API - [Official Docs](https://developers.facebook.com/docs/messenger-platform/user-profile)
 
-- [getUserProfile](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getuserprofile)
+- [getUserProfile](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getuserprofile)
 
 <br />
 
@@ -266,9 +266,9 @@ Those methods have exactly same argument signature with the methods on client.
 
 ### Messenger Profile API - [Official Docs](https://developers.facebook.com/docs/messenger-platform/messenger-profile)
 
-- [getMessengerProfile](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getmessengerprofile)
-- [setMessengerProfile](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#setmessengerprofile)
-- [deleteMessengerProfile](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#deletemessengerprofile)
+- [getMessengerProfile](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getmessengerprofile)
+- [setMessengerProfile](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#setmessengerprofile)
+- [deleteMessengerProfile](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#deletemessengerprofile)
 
 <a id="persistent-menu" />
 
@@ -276,9 +276,9 @@ Those methods have exactly same argument signature with the methods on client.
 
 ![](https://scontent-tpe1-1.xx.fbcdn.net/v/t39.2365-6/16686128_804279846389859_443648268883197952_n.png?oh=adde03b0bc7dd524a58cf46016e0267d&oe=59FC90D6)
 
-- [getPersistentMenu](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getpersistentmenu)
-- [setPersistentMenu](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#setpersistentmenu)
-- [deletePersistentMenu](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#deletepersistentmenu)
+- [getPersistentMenu](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getpersistentmenu)
+- [setPersistentMenu](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#setpersistentmenu)
+- [deletePersistentMenu](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#deletepersistentmenu)
 
 <a id="get-started-button" />
 
@@ -286,9 +286,9 @@ Those methods have exactly same argument signature with the methods on client.
 
 <img src="https://scontent-tpe1-1.xx.fbcdn.net/v/t39.2365-6/14302685_243106819419381_1314180151_n.png?oh=9487042d8c0067eb2fda1efa45d0e17b&oe=59F7185C" alt="Get Started Button" width="500" />
 
-- [getGetStarted](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getgetstarted)
-- [setGetStarted](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#setgetstarted)
-- [deleteGetStarted](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#deletegetstarted)
+- [getGetStarted](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getgetstarted)
+- [setGetStarted](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#setgetstarted)
+- [deleteGetStarted](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#deletegetstarted)
 
 <a id="greeting-text" />
 
@@ -296,34 +296,34 @@ Those methods have exactly same argument signature with the methods on client.
 
 <img src="https://scontent-tpe1-1.xx.fbcdn.net/v/t39.2365-6/14287888_188235318253964_1078929636_n.png?oh=a1171ab50f04d3a244ed703eafd2dbef&oe=59F01AF5" alt="Greeting Text" width="250" />
 
-- [getGreeting](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getgreeting)
-- [setGreeting](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#setgreeting)
-- [deleteGreeting](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#deletegreeting)
+- [getGreeting](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getgreeting)
+- [setGreeting](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#setgreeting)
+- [deleteGreeting](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#deletegreeting)
 
 <a id="domain-whitelist" />
 
 ### Whitelisted Domains - [Official Docs](https://developers.facebook.com/docs/messenger-platform/messenger-profile/domain-whitelisting)
 
-- [getWhitelistedDomains](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getwhitelisteddomains)
-- [setWhitelistedDomains](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#setwhitelisteddomains)
-- [deleteWhitelistedDomains](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#deletewhitelisteddomains)
+- [getWhitelistedDomains](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getwhitelisteddomains)
+- [setWhitelistedDomains](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#setwhitelisteddomains)
+- [deleteWhitelistedDomains](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#deletewhitelisteddomains)
 
 <a id="account-linking-url" />
 
 ### Account Linking URL - [Official Docs](https://developers.facebook.com/docs/messenger-platform/reference/messenger-profile-api/account-linking-url)
 
-- [getAccountLinkingURL](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getaccountlinkingurl)
-- [setAccountLinkingURL](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#setaccountlinkingurl)
-- [deleteAccountLinkingURL](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#deleteaccountlinkingurl)
+- [getAccountLinkingURL](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getaccountlinkingurl)
+- [setAccountLinkingURL](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#setaccountlinkingurl)
+- [deleteAccountLinkingURL](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#deleteaccountlinkingurl)
 
 ### Handover Protocol API
 
-- [passThreadControl](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#passthreadcontrol)
-- [passThreadControlToPageInbox](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#passthreadcontroltopageinbox)
-- [takeThreadControl](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#takethreadcontrol)
-- [requestThreadControl](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#requestthreadcontrol)
-- [getThreadOwner](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getthreadowner)
-- [getSecondaryReceivers](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getsecondaryreceivers)
+- [passThreadControl](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#passthreadcontrol)
+- [passThreadControlToPageInbox](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#passthreadcontroltopageinbox)
+- [takeThreadControl](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#takethreadcontrol)
+- [requestThreadControl](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#requestthreadcontrol)
+- [getThreadOwner](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getthreadowner)
+- [getSecondaryReceivers](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getsecondaryreceivers)
 
 <br />
 
@@ -336,11 +336,11 @@ Requirements for insights API:
 - The page token must have `read_insights` permission.
 - Insights are only generated for a Facebook Page that has more than `30` people that like it.
 
-- [getInsights](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getinsights)
-- [getBlockedConversations](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getblockedconversations)
-- [getReportedConversations](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getreportedconversations)
-- [getTotalMessagingConnections](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#gettotalmessagingconnections)
-- [getNewConversations](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getnewconversations)
+- [getInsights](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getinsights)
+- [getBlockedConversations](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getblockedconversations)
+- [getReportedConversations](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getreportedconversations)
+- [getTotalMessagingConnections](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#gettotalmessagingconnections)
+- [getNewConversations](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getnewconversations)
 
 <br />
 
@@ -348,9 +348,9 @@ Requirements for insights API:
 
 ### Built-in NLP API - [Official Docs](https://developers.facebook.com/docs/messenger-platform/built-in-nlp)
 
-- [setNLPConfigs](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#setnlpconfigs)
-- [enableNLP](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#enablenlp)
-- [disableNLP](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#disablenlp)
+- [setNLPConfigs](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#setnlpconfigs)
+- [enableNLP](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#enablenlp)
+- [disableNLP](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#disablenlp)
 
 <br />
 
@@ -358,14 +358,14 @@ Requirements for insights API:
 
 ### Event Logging API - [Official Docs](https://developers.facebook.com/docs/app-events/bots-for-messenger#logging-custom-events)
 
-- [logCustomEvents](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#logcustomevents)
+- [logCustomEvents](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#logcustomevents)
 
 <a id="id-matching-api" />
 
 ### ID Matching API - [Official Docs](https://developers.facebook.com/docs/messenger-platform/identity/id-matching)
 
-- [getIdsForApps](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getidsforapps)
-- [getIdsForPages](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getidsforpages)
+- [getIdsForApps](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getidsforapps)
+- [getIdsForPages](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getidsforpages)
 
 <br />
 
@@ -373,22 +373,22 @@ Requirements for insights API:
 
 ### Persona API - [Official Docs](https://developers.facebook.com/docs/messenger-platform/send-messages/personas)
 
-- [createPersona](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#createpersona)
-- [getPersona](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getpersona)
-- [getPersonas](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getpersonas)
-- [getAllPersonas](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getallpersonas)
-- [deletePersona](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#deletepersona)
+- [createPersona](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#createpersona)
+- [getPersona](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getpersona)
+- [getPersonas](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getpersonas)
+- [getAllPersonas](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getallpersonas)
+- [deletePersona](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#deletepersona)
 
 <br />
 
 ### Others
 
-- [debugToken](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#debugtoken)
-- [createSubscription](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#createsubscription)
-- [getSubscriptions](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getsubscriptions)
-- [getPageSubscription](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getpagesubscription)
-- [getPageInfo](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getpageinfo)
-- [getMessagingFeatureReview](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getmessagingfeaturereview)
+- [debugToken](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#debugtoken)
+- [createSubscription](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#createsubscription)
+- [getSubscriptions](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getsubscriptions)
+- [getPageSubscription](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getpagesubscription)
+- [getPageInfo](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getpageinfo)
+- [getMessagingFeatureReview](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_messenger.MessengerClient.html#getmessagingfeaturereview)
 
 <br />
 

--- a/packages/messaging-api-slack/README.md
+++ b/packages/messaging-api-slack/README.md
@@ -89,32 +89,32 @@ client.callMethod('chat.postMessage', { channel: 'C8763', text: 'Hello!' });
 
 #### Chat API
 
-- [chat.postMessage](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#chat)
-- [chat.postEphemeral](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#chat)
+- [chat.postMessage](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOAuthClient.html#chat)
+- [chat.postEphemeral](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOAuthClient.html#chat)
 
 <br />
 
 #### Users API
 
-- [getUserList](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getuserlist)
-- [getAllUserList](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getalluserlist)
-- [getUserInfo](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getuserinfo)
+- [getUserList](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOAuthClient.html#getuserlist)
+- [getAllUserList](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOAuthClient.html#getalluserlist)
+- [getUserInfo](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOAuthClient.html#getuserinfo)
 
 <br />
 
 #### Channels API
 
-- [getChannelInfo](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getchannelinfo)
+- [getChannelInfo](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOAuthClient.html#getchannelinfo)
 
 <br />
 
 #### Conversations API
 
-- [getConversationInfo](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getconversationinfo)
-- [getConversationMembers](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getconversationmembers)
-- [getAllConversationMembers](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getallconversationmembers)
-- [getConversationList](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getconversationlist)
-- [getAllConversationList](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getallconversationlist)
+- [getConversationInfo](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOAuthClient.html#getconversationinfo)
+- [getConversationMembers](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOAuthClient.html#getconversationmembers)
+- [getAllConversationMembers](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOAuthClient.html#getallconversationmembers)
+- [getConversationList](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOAuthClient.html#getconversationlist)
+- [getAllConversationList](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOAuthClient.html#getallconversationlist)
 
 <br />
 

--- a/packages/messaging-api-slack/README.md
+++ b/packages/messaging-api-slack/README.md
@@ -89,32 +89,32 @@ client.callMethod('chat.postMessage', { channel: 'C8763', text: 'Hello!' });
 
 #### Chat API
 
-- [chat.postMessage](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#chat)
-- [chat.postEphemeral](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#chat)
+- [chat.postMessage](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#chat)
+- [chat.postEphemeral](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#chat)
 
 <br />
 
 #### Users API
 
-- [getUserList](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getuserlist)
-- [getAllUserList](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getalluserlist)
-- [getUserInfo](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getuserinfo)
+- [getUserList](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getuserlist)
+- [getAllUserList](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getalluserlist)
+- [getUserInfo](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getuserinfo)
 
 <br />
 
 #### Channels API
 
-- [getChannelInfo](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getchannelinfo)
+- [getChannelInfo](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getchannelinfo)
 
 <br />
 
 #### Conversations API
 
-- [getConversationInfo](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getconversationinfo)
-- [getConversationMembers](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getconversationmembers)
-- [getAllConversationMembers](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getallconversationmembers)
-- [getConversationList](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getconversationlist)
-- [getAllConversationList](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getallconversationlist)
+- [getConversationInfo](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getconversationinfo)
+- [getConversationMembers](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getconversationmembers)
+- [getAllConversationMembers](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getallconversationmembers)
+- [getConversationList](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getconversationlist)
+- [getAllConversationList](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#getallconversationlist)
 
 <br />
 
@@ -144,10 +144,10 @@ All methods return a Promise.
 
 ### Send API - [Official docs](https://api.slack.com/docs/messages)
 
-- [sendRawBody](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackWebhookClient.html#sendrawbody)
-- [sendText](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackWebhookClient.html#sendtext)
-- [sendAttachments](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackWebhookClient.html#sendattachments)
-- [sendAttachment](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackWebhookClient.html#sendattachment)
+- [sendRawBody](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackWebhookClient.html#sendrawbody)
+- [sendText](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackWebhookClient.html#sendtext)
+- [sendAttachments](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackWebhookClient.html#sendattachments)
+- [sendAttachment](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackWebhookClient.html#sendattachment)
 
 <br />
 

--- a/packages/messaging-api-viber/README.md
+++ b/packages/messaging-api-viber/README.md
@@ -73,23 +73,23 @@ All methods return a Promise.
 
 ### Webhook API
 
-- [setWebhook](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#setwebhook)
-- [removeWebhook](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#removewebhook)
+- [setWebhook](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#setwebhook)
+- [removeWebhook](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#removewebhook)
 
 <br />
 
 ### Send API
 
-- [sendMessage](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendmessage)
-- [sendText](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendtext)
-- [sendPicture](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendpicture)
-- [sendVideo](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendvideo)
-- [sendFile](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendfile)
-- [sendContact](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendcontact)
-- [sendLocation](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendlocation)
-- [sendURL](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendurl)
-- [sendSticker](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendsticker)
-- [sendCarouselContent](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendcarouselcontent)
+- [sendMessage](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendmessage)
+- [sendText](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendtext)
+- [sendPicture](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendpicture)
+- [sendVideo](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendvideo)
+- [sendFile](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendfile)
+- [sendContact](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendcontact)
+- [sendLocation](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendlocation)
+- [sendURL](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendurl)
+- [sendSticker](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendsticker)
+- [sendCarouselContent](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#sendcarouselcontent)
 
 <br />
 
@@ -137,16 +137,16 @@ client.sendText(USER_ID, 'Hello', {
 
 Those API methods use the same parameters as the send methods with a few variations described below. You should specify a list of receivers instead of a single receiver.
 
-- [broadcastMessage](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcastmessage)
-- [broadcastText](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcasttext)
-- [broadcastPicture](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcastpicture)
-- [broadcastVideo](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcastvideo)
-- [broadcastFile](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcastfile)
-- [broadcastContact](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcastcontact)
-- [broadcastLocation](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcastlocation)
-- [broadcastURL](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcasturl)
-- [broadcastSticker](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcaststicker)
-- [broadcastCarouselContent](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcastcarouselcontent)
+- [broadcastMessage](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcastmessage)
+- [broadcastText](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcasttext)
+- [broadcastPicture](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcastpicture)
+- [broadcastVideo](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcastvideo)
+- [broadcastFile](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcastfile)
+- [broadcastContact](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcastcontact)
+- [broadcastLocation](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcastlocation)
+- [broadcastURL](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcasturl)
+- [broadcastSticker](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcaststicker)
+- [broadcastCarouselContent](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#broadcastcarouselcontent)
 
 | Param         | Type            | Description                                                                                                                                                        |
 | ------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -187,19 +187,19 @@ await client.broadcastText(
 
 ### Get Account Info
 
-- [getAccountInfo](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#getaccountinfo)
+- [getAccountInfo](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#getaccountinfo)
 
 <br />
 
 ### Get User Details
 
-- [getUserDetails](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#getuserdetails)
+- [getUserDetails](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#getuserdetails)
 
 <br />
 
 ### Get Online
 
-- [getOnlineStatus](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#getonlinestatus)
+- [getOnlineStatus](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_viber.ViberClient.html#getonlinestatus)
 
 <br />
 

--- a/packages/messaging-api-wechat/README.md
+++ b/packages/messaging-api-wechat/README.md
@@ -66,22 +66,22 @@ All methods return a Promise.
 
 ### Send API - [Official Docs](https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1421140547)
 
-- [sendText](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#sendtext)
-- [sendImage](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#sendimage)
-- [sendVoice](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#sendvoice)
-- [sendVideo](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#sendvideo)
-- [sendMusic](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#sendmusic)
-- [sendNews](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#sendnews)
-- [sendMPNews](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#sendmpnews)
-- [sendWXCard](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#sendwxcard)
-- [sendMiniProgramPage](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#sendminiprogrampage)
+- [sendText](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#sendtext)
+- [sendImage](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#sendimage)
+- [sendVoice](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#sendvoice)
+- [sendVideo](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#sendvideo)
+- [sendMusic](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#sendmusic)
+- [sendNews](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#sendnews)
+- [sendMPNews](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#sendmpnews)
+- [sendWXCard](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#sendwxcard)
+- [sendMiniProgramPage](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#sendminiprogrampage)
 
 <a id="media-api" />
 
 ### Media API - [Official Docs](https://mp.weixin.qq.com/wiki?t=resource/res_main&id=mp1421140547)
 
-- [uploadMedia](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#uploadmedia)
-- [getMedia](https://yoctol.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#getmedia)
+- [uploadMedia](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#uploadmedia)
+- [getMedia](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_wechat.WechatClient.html#getmedia)
 
 ## Debug Tips
 


### PR DESCRIPTION
Tested several links, seems working.

Also, I found that some slack links still won't work, but fixing the case of `O"A"uth` will work.


#### Chat API

// BROKEN
- [chat.postMessage](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#chat)
- [chat.postEphemeral](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOauthClient.html#chat)

// WORKING
- [chat.postMessage](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOAuthClient.html#chat)
- [chat.postEphemeral](https://bottenderjs.github.io/messaging-apis/latest/classes/messaging_api_slack.SlackOAuthClient.html#chat)
